### PR TITLE
fix: Add support for directives with a different kind of meta

### DIFF
--- a/lib/mock_directive.spec.ts
+++ b/lib/mock_directive.spec.ts
@@ -1,4 +1,5 @@
 import { Component, Directive, Input } from '@angular/core';
+import { FormControlDirective } from '@angular/forms';
 import { async, ComponentFixture, getTestBed, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import {
@@ -63,5 +64,15 @@ describe('MockComponent', () => {
   it('should memoize the return value by argument', () => {
     expect(MockDirective(ExampleDirective)).toEqual(MockDirective(ExampleDirective));
     expect(MockDirective(ExampleDirective)).not.toEqual(ExampleDirective);
+  });
+
+  it('can mock formControlDirective from angular', () => {
+    // Some angular directives set up their metadata in a different way than @Directive does
+    // I found that FormControlDirective is one of those weird directives.
+    // Since I don't know how they did it, I don't know how to test it except to write this
+    // test around a known-odd directive.
+    expect(() => {
+      MockDirective(FormControlDirective);
+    }).not.toThrow();
   });
 });

--- a/lib/mock_directive.ts
+++ b/lib/mock_directive.ts
@@ -8,15 +8,25 @@ export function MockDirective<TDirective>(directive: Type<TDirective>): Type<TDi
     return cacheHit as Type<TDirective>;
   }
 
-  const annotations = (directive as any).__annotations__[0] || {};
+  let annotation: any = {};
+  const annotations: any[] = (directive as any).__annotations__;
+  if (annotations) {
+    annotation = annotations[0];
+  } else {
+    if (!directive.hasOwnProperty('decorators')) {
+      throw new Error(`Cannot find the annotations/decorators for directive ${directive.name}`);
+    }
+    return (directive as any).decorators[0].args[0];
+  }
+
   const propertyMetadata = (directive as any).__prop__metadata__ || {};
 
   const options: Directive = {
-    exportAs: annotations.exportAs,
+    exportAs: annotation.exportAs,
     inputs: Object.keys(propertyMetadata)
                   .filter((meta) => isInput(propertyMetadata[meta]))
                   .map((meta) => [meta, propertyMetadata[meta][0].bindingPropertyName || meta].join(':')),
-    selector: annotations.selector
+    selector: annotation.selector
   };
 
   const mockedDirective =  Directive(options)(class DirectiveMock {} as Type<TDirective>);

--- a/package-lock.json
+++ b/package-lock.json
@@ -31,6 +31,15 @@
         "tslib": "1.8.0"
       }
     },
+    "@angular/forms": {
+      "version": "5.2.4",
+      "resolved": "https://registry.npmjs.org/@angular/forms/-/forms-5.2.4.tgz",
+      "integrity": "sha512-0k6rs2k85wcBq0WPAjxNbtBu1wq/1fUSFaBLbpnrwwHeCLJI5aAjG2/f3jv/17a/ek7/WZ3lxXtHzNMMdaD/Iw==",
+      "dev": true,
+      "requires": {
+        "tslib": "1.8.0"
+      }
+    },
     "@angular/platform-browser": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/@angular/platform-browser/-/platform-browser-5.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "@angular/common": "5.x",
     "@angular/compiler": "5.x",
     "@angular/core": "5.x",
+    "@angular/forms": "5.x",
     "@angular/platform-browser": "5.x",
     "@angular/platform-browser-dynamic": "5.x",
     "@types/core-js": "^0.9.43",


### PR DESCRIPTION
My guess is that the mock_component may suffer from the same issue but I haven't confirmed it yet. May be a good reason to merge the repos and share the logic that extracts the directive attributes. Then just build separate packages from the same repo. Could also export a parent one that gives them all. Kinda like lodash?

I think npm packages can work like this??

One parent package:
`$> npm i --save-dev coolMockTool`
then
```typescript
import {MockDirective, MockComponent} from 'coolMockPackageName';
```

Alternatively, if you just want one of the sub packages:
`$> npm i --save-dev coolMockTool/mock-directive`
```typescript
import { MockDirective } from 'coolMockTool/mock-directive';
``` 
